### PR TITLE
implement idle shutdown and scheduled cache pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The following options exist:
   Log level of the credential helper. Debug may expose sensitive information. Default is off.
 - `$CREDENTIAL_HELPER_IDLE_TIMEOUT`:
   Idle timeout of the agent in [Go duration format][go_duration]. The agent will run in the background and wait for connections until the idle timeout is reached. Defaults to 3h. A negative value disables idle shutdowns.
+- `$CREDENTIAL_HELPER_PRUNE_INTERVAL`:
+  Duration between cache prunes in [Go duration format][go_duration]. Defaults to 1m. A negative value disables cache pruning.
 
 
 ## Troubleshooting

--- a/agent/agent_rpc_test.go
+++ b/agent/agent_rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tweag/credential-helper/cache"
@@ -194,9 +195,11 @@ func setup() (CachingAgent, *testListener) {
 	lis := newTestListener()
 
 	return CachingAgent{
-		cache:        cache.NewMemCache(),
-		lis:          lis,
-		shutdownChan: make(chan struct{}),
+		cache:         cache.NewMemCache(),
+		lis:           lis,
+		shutdownChan:  make(chan struct{}),
+		idleTimeout:   -time.Microsecond, // disable idle timeout for test
+		pruneInterval: -time.Microsecond, // disable pruning schedule for test
 	}, lis
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -82,6 +82,7 @@ const (
 	AgentPidPath        = "CREDENTIAL_HELPER_AGENT_PID"
 	LogLevelEnv         = "CREDENTIAL_HELPER_LOGGING"
 	IdleTimeoutEnv      = "CREDENTIAL_HELPER_IDLE_TIMEOUT"
+	PruneIntervalEnv    = "CREDENTIAL_HELPER_PRUNE_INTERVAL"
 	// The working directory for the agent and client process.
 	// On startup, we chdir into it.
 	WorkdirEnv = "CREDENTIAL_HELPER_WORKDIR"

--- a/tools/credential-helper
+++ b/tools/credential-helper
@@ -27,6 +27,9 @@ set -o errtrace
 #   Idle timeout of the agent in Go duration format.
 #   The agent will run in the background and wait for connections until the idle timeout is reached.
 #   Defaults to 3h.
+# export CREDENTIAL_HELPER_PRUNE_INTERVAL=duration
+#   Duration between cache prunes in Go duration format.
+#   Defaults to 1m.
 
 credential_helper_install_command="bazel run @tweag-credential-helper//installer"
 


### PR DESCRIPTION
Idle shutdown is configurable via CREDENTIAL_HELPER_IDLE_TIMEOUT environment variable.
Cache pruning is configurable via CREDENTIAL_HELPER_PRUNE_INTERVAL environment variable.