### PR TITLE
logging: write request URI to syslog in debug mode

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -80,6 +80,12 @@ func foreground(ctx context.Context, cache api.Cache, helperFactory api.HelperFa
 		logging.Fatalf("%v", err)
 	}
 
+	// The credential helper is often invoked by other tools,
+	// so there is no reliable way to ensure that the stderr
+	// of the credential helper is visible to the user.
+	// Therefore, we log every request to syslog in debug mode.
+	logging.SyslogDebugf(req.URI)
+
 	ctx, authenticator := util.Configure(ctx, helperFactory, configReader, req.URI)
 
 	cacheKey := authenticator.CacheKey(req)

--- a/logging/BUILD.bazel
+++ b/logging/BUILD.bazel
@@ -2,7 +2,11 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "logging",
-    srcs = ["logging.go"],
+    srcs = [
+        "logging.go",
+        "syslog_fallback.go",
+        "syslog_linux.go",
+    ],
     importpath = "github.com/tweag/credential-helper/logging",
     visibility = ["//visibility:public"],
 )

--- a/logging/syslog_fallback.go
+++ b/logging/syslog_fallback.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package logging
+
+// Outside of linux, we aren't guaranteed to have syslog available.
+// So we'll just fall back to the standard logging functions.
+func SyslogDebugf(format string, args ...any) {
+	Debugf(format, args...)
+}

--- a/logging/syslog_linux.go
+++ b/logging/syslog_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package logging
+
+import "log/syslog"
+
+// On Linux, we attempt to write to the syslog.
+func SyslogDebugf(format string, args ...any) {
+	if level < LogLevelDebug {
+		return
+	}
+	syslogger, err := syslog.NewLogger(syslog.LOG_DEBUG, 0)
+	if err == nil {
+		allArgs := append([]any{format}, args...)
+		syslogger.Println(allArgs...)
+	}
+}


### PR DESCRIPTION
The credential helper is often invoked by other tools, so there is no reliable way to ensure that the stderr of the credential helper is visible to the user.
Therefore, we log every request to syslog in debug mode.