### PR TITLE
Support GCS as remote cache

### DIFF
--- a/authenticate/gcs/gcs.go
+++ b/authenticate/gcs/gcs.go
@@ -67,8 +67,11 @@ func (g *GCSResolver) Get(ctx context.Context, req api.GetCredentialsRequest) (a
 		return api.GetCredentialsResponse{}, errors.New("only https is supported")
 	}
 
-	if parsedURL.Host != "storage.googleapis.com" {
+	if parsedURL.Hostname() != "storage.googleapis.com" {
 		return api.GetCredentialsResponse{}, errors.New("only storage.googleapis.com is supported")
+	}
+	if parsedURL.Port() != "" && parsedURL.Port() != "443" {
+		return api.GetCredentialsResponse{}, errors.New("only port 443 is supported")
 	}
 
 	token, err := g.tokenSource.Token()

--- a/docs/providers/gcs.md
+++ b/docs/providers/gcs.md
@@ -1,10 +1,10 @@
 # Google Cloud Storage (GCS) Authentication
 
-This document explains how to setup your system for authenticating to Google Cloud Storage (GCS) using the credential helper to download objects.
+This document explains how to setup your system for authenticating to Google Cloud Storage (GCS) using the credential helper to download objects, or use a bucket as a HTTP/1.1 remote cache.
 
 ## IAM Setup
 
-In order to access data from a bucket, you need a Google Cloud user- or service account with read access to the objects you want to access (`storage.objects.get`). No other permissions are needed.
+In order to access data from a bucket, you need a Google Cloud user- or service account with read access to the objects you want to access (`storage.objects.get`). No other permissions are needed to download objects.
 Refer to [Google's documentation][gcs-iam] for more information.
 
 
@@ -31,6 +31,12 @@ Add to your `.bazelrc`:
 
 ```
 common --credential_helper=storage.googleapis.com=%workspace%/tools/credential-helper
+```
+
+Additionally, you can configure a GCS bucket to be a HTTP/1.1 remote cache:
+
+```
+build --remote_cache=https://storage.googleapis.com/my_bucket
 ```
 
 ## Troubleshooting

--- a/docs/providers/remoteapis.md
+++ b/docs/providers/remoteapis.md
@@ -17,6 +17,7 @@ When using one of the following services, you can directly jump to the matching 
 - [Self-hosted BuildBuddy](#section-buildbuddy-self-hosted)
 - [BuildBarn](#section-buildbarn)
 - [bazel-remote](#section-bazel-remote)
+- [Google Cloud Storage (GCS) bucket as HTTP/1.1 cache](/docs/providers/gcs.md)
 
 
 ## Configuration

--- a/helperfactory/fallback/fallback_factory.go
+++ b/helperfactory/fallback/fallback_factory.go
@@ -20,42 +20,42 @@ func FallbackHelperFactory(rawURL string) (api.Helper, error) {
 		return nil, err
 	}
 	switch {
-	case strings.HasSuffix(u.Host, ".amazonaws.com"):
+	case strings.HasSuffix(u.Hostname(), ".amazonaws.com"):
 		return &authenticateS3.S3{}, nil
-	case strings.EqualFold(u.Host, "storage.googleapis.com"):
+	case strings.EqualFold(u.Hostname(), "storage.googleapis.com"):
 		return &authenticateGCS.GCS{}, nil
-	case strings.EqualFold(u.Host, "github.com"):
+	case strings.EqualFold(u.Hostname(), "github.com"):
 		fallthrough
 	case strings.HasSuffix(strings.ToLower(u.Host), ".github.com"):
 		fallthrough
-	case strings.EqualFold(u.Host, "raw.githubusercontent.com"):
+	case strings.EqualFold(u.Hostname(), "raw.githubusercontent.com"):
 		return &authenticateGitHub.GitHub{}, nil
-	case strings.HasSuffix(strings.ToLower(u.Host), ".r2.cloudflarestorage.com") && !u.Query().Has("X-Amz-Expires"):
+	case strings.HasSuffix(strings.ToLower(u.Hostname()), ".r2.cloudflarestorage.com") && !u.Query().Has("X-Amz-Expires"):
 		return &authenticateS3.S3{}, nil
-	case strings.EqualFold(u.Host, "remote.buildbuddy.io"):
+	case strings.EqualFold(u.Hostname(), "remote.buildbuddy.io"):
 		return &authenticateRemoteAPIs.RemoteAPIs{}, nil
 	// container registries using the default OCI resolver
-	case strings.HasSuffix(u.Host, ".app.snowflake.com"):
+	case strings.HasSuffix(u.Hostname(), ".app.snowflake.com"):
 		fallthrough
-	case strings.HasSuffix(u.Host, ".azurecr.io"):
+	case strings.HasSuffix(u.Hostname(), ".azurecr.io"):
 		fallthrough
-	case strings.EqualFold(u.Host, "cgr.dev"):
+	case strings.EqualFold(u.Hostname(), "cgr.dev"):
 		fallthrough
-	case strings.EqualFold(u.Host, "docker.elastic.co"):
+	case strings.EqualFold(u.Hostname(), "docker.elastic.co"):
 		fallthrough
-	case strings.EqualFold(u.Host, "gcr.io"):
+	case strings.EqualFold(u.Hostname(), "gcr.io"):
 		fallthrough
-	case strings.EqualFold(u.Host, "ghcr.io"):
+	case strings.EqualFold(u.Hostname(), "ghcr.io"):
 		fallthrough
-	case strings.EqualFold(u.Host, "index.docker.io"):
+	case strings.EqualFold(u.Hostname(), "index.docker.io"):
 		fallthrough
-	case strings.EqualFold(u.Host, "nvcr.io"):
+	case strings.EqualFold(u.Hostname(), "nvcr.io"):
 		fallthrough
-	case strings.EqualFold(u.Host, "public.ecr.aws"):
+	case strings.EqualFold(u.Hostname(), "public.ecr.aws"):
 		fallthrough
-	case strings.EqualFold(u.Host, "quay.io"):
+	case strings.EqualFold(u.Hostname(), "quay.io"):
 		fallthrough
-	case strings.EqualFold(u.Host, "registry.gitlab.com"):
+	case strings.EqualFold(u.Hostname(), "registry.gitlab.com"):
 		return authenticateOCI.NewFallbackOCI(), nil
 	default:
 		if authenticateOCI.GuessOCIRegistry(rawURL) {

--- a/testdata/gcs_http_remote_cache.json
+++ b/testdata/gcs_http_remote_cache.json
@@ -1,0 +1,1 @@
+{"uri":"https://storage.googleapis.com:443/rules_gcs"}


### PR DESCRIPTION
Bazel can use any HTTP/1.1 server as a remote cache, including GCS buckets. Surprisingly, requests made by Bazel's downloader use a canonical request uri (`https://storage.googleapis.com/...`), while requests to the HTTP remote cache explicitly include the port number, but are also routed to the credential helper (`https://storage.googleapis.com:443/...`).

Fixes #40
Co-authored-by: @jmeickle-theaiinstitute