### PR TITLE
Add 'version' command

### DIFF
--- a/cmd/root/BUILD.bazel
+++ b/cmd/root/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["root.go"],
     importpath = "github.com/tweag/credential-helper/cmd/root",
     visibility = ["//visibility:public"],
+    x_defs = {"version": module_version()},
     deps = [
         "//agent",
         "//agent/locate",

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -22,12 +22,17 @@ import (
 	"github.com/tweag/credential-helper/logging"
 )
 
+// the value of this variable is intended to be substituted with the actual tool
+// version using the linker's stamping feature (i.e., using a `-X` argument)
+var version = "0.0.0"
+
 const usage = `Usage: credential-helper [COMMAND] [ARGS...]
 
 Commands:
   get            get credentials in the form of http headers for the uri provided on stdin and print result to stdout (see https://github.com/EngFlow/credential-helper-spec for more information)
   setup-uri      prints setup instructions for a given uri
-  setup-keyring  stores a secret in the system keyring`
+  setup-keyring  stores a secret in the system keyring
+  version        displays the version of this tool`
 
 func Run(ctx context.Context, helperFactory api.HelperFactory, newCache api.NewCache, args []string) {
 	setLogLevel()
@@ -65,6 +70,8 @@ func Run(ctx context.Context, helperFactory api.HelperFactory, newCache api.NewC
 		clientCommandProcess(args[2], os.Stdin)
 	case "installer-install":
 		installer.InstallerProcess()
+	case "version":
+		fmt.Println(version)
 	default:
 		logging.Fatalf("unknown command")
 	}


### PR DESCRIPTION
This PR adds the `version` command to the credential helper. This can be convenient when managing the installed credential helper version manually or using an external automation tool such as Chef or Ansible.

The version of the tool is kept in sync with the Bazel module version using rules_go's "stamping" mechanism.