### PR TITLE
Use a local httpbin server for the integration tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -62,3 +62,13 @@ go_sdk.download(version = "1.24.2")
 
 module_version = use_extension("//bzl/private/config:defs.bzl", "module_version", dev_dependency = True)
 use_repo(module_version, "tweag-credential-helper-version")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "go_httpbin",
+    url = "https://github.com/mccutchen/go-httpbin/archive/refs/tags/v2.18.3.tar.gz",
+    integrity = "sha256-POrxD78ramS8zCt4GRORph5tgH5fHYQSnM7uUdR1soE=",
+    patches = ["//bzl/private/httpbin:patches/bzlmod.patch"],
+    patch_args = ["-p1"],
+    strip_prefix = "go-httpbin-2.18.3"
+)

--- a/bzl/private/httpbin/BUILD.bazel
+++ b/bzl/private/httpbin/BUILD.bazel
@@ -1,0 +1,12 @@
+alias(
+    name = "httpbin",
+    actual = "@go_httpbin//cmd/go-httpbin:go-httpbin",
+    visibility = ["//visibility:public"],
+)
+
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/bzl/private/httpbin/patches/bzlmod.patch
+++ b/bzl/private/httpbin/patches/bzlmod.patch
@@ -1,0 +1,123 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000..abccfc7
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,3 @@
++load("@gazelle//:def.bzl", "gazelle")
++
++gazelle(name = "gazelle")
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..78088a3
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,5 @@
++bazel_dep(name = "rules_go", version = "0.46.0")
++bazel_dep(name = "gazelle", version = "0.37.0")
++
++go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
++go_sdk.download(version = "1.23.1")
+diff --git a/cmd/go-httpbin/BUILD.bazel b/cmd/go-httpbin/BUILD.bazel
+new file mode 100644
+index 0000000..3c5a6f7
+--- /dev/null
++++ b/cmd/go-httpbin/BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "go-httpbin_lib",
++    srcs = ["main.go"],
++    importpath = "github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin",
++    visibility = ["//visibility:private"],
++    deps = ["//httpbin/cmd"],
++)
++
++go_binary(
++    name = "go-httpbin",
++    embed = [":go-httpbin_lib"],
++    visibility = ["//visibility:public"],
++)
+diff --git a/httpbin/BUILD.bazel b/httpbin/BUILD.bazel
+new file mode 100644
+index 0000000..709aee7
+--- /dev/null
++++ b/httpbin/BUILD.bazel
+@@ -0,0 +1,33 @@
++load("@rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "httpbin",
++    srcs = [
++        "doc.go",
++        "handlers.go",
++        "helpers.go",
++        "httpbin.go",
++        "middleware.go",
++        "options.go",
++        "responses.go",
++        "static_assets.go",
++    ],
++    embedsrcs = [
++        "static/forms-post.html.tmpl",
++        "static/image.jpeg",
++        "static/image.png",
++        "static/image.svg",
++        "static/image.webp",
++        "static/index.html.tmpl",
++        "static/moby.html",
++        "static/sample.json",
++        "static/sample.xml",
++        "static/utf8.html",
++    ],
++    importpath = "github.com/mccutchen/go-httpbin/v2/httpbin",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//httpbin/digest",
++        "//httpbin/websocket",
++    ],
++)
+diff --git a/httpbin/cmd/BUILD.bazel b/httpbin/cmd/BUILD.bazel
+new file mode 100644
+index 0000000..8840eab
+--- /dev/null
++++ b/httpbin/cmd/BUILD.bazel
+@@ -0,0 +1,9 @@
++load("@rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "cmd",
++    srcs = ["cmd.go"],
++    importpath = "github.com/mccutchen/go-httpbin/v2/httpbin/cmd",
++    visibility = ["//visibility:public"],
++    deps = ["//httpbin"],
++)
+diff --git a/httpbin/digest/BUILD.bazel b/httpbin/digest/BUILD.bazel
+new file mode 100644
+index 0000000..f4eabcb
+--- /dev/null
++++ b/httpbin/digest/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "digest",
++    srcs = ["digest.go"],
++    importpath = "github.com/mccutchen/go-httpbin/v2/httpbin/digest",
++    visibility = ["//visibility:public"],
++)
+diff --git a/httpbin/websocket/BUILD.bazel b/httpbin/websocket/BUILD.bazel
+new file mode 100644
+index 0000000..143f349
+--- /dev/null
++++ b/httpbin/websocket/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "websocket",
++    srcs = ["websocket.go"],
++    importpath = "github.com/mccutchen/go-httpbin/v2/httpbin/websocket",
++    visibility = ["//visibility:public"],
++)

--- a/bzl/private/integration_test_runner/BUILD.bazel
+++ b/bzl/private/integration_test_runner/BUILD.bazel
@@ -14,6 +14,7 @@ go_binary(
         ":bazel_dep_credential_helper",
         "//bzl/private/release:airgapped",
         "//bzl/private/release:bcr",
+        "//bzl/private/httpbin",
     ],
     embed = [":integration_test_runner_lib"],
     visibility = ["//visibility:public"],

--- a/examples/customized/.bazelrc
+++ b/examples/customized/.bazelrc
@@ -10,9 +10,9 @@ common:freebsd --config=unix
 common:openbsd --config=unix
 
 # credential helpers for Unix
-common:unix --credential_helper=httpbin.org=%workspace%/tools/credential-helper
+common:unix --credential_helper=127.0.0.1=%workspace%/tools/credential-helper
 
 # credential helpers for Windows
-common:windows --credential_helper=httpbin.org=%workspace%/tools/credential-helper.exe
+common:windows --credential_helper=127.0.0.1=%workspace%/tools/credential-helper.exe
 
 try-import %workspace%/.bazelrc.user

--- a/examples/customized/BUILD.bazel
+++ b/examples/customized/BUILD.bazel
@@ -29,7 +29,7 @@ check_file_hash_test(
     name = "check_httpbin_basic_auth",
     args = [
         "$(location @httpbin_basic_auth//file)",
-        "862df46c49d3993226614a265acc0460169eb9d16951d581e9f139153ad95138",
+        "6e115a4749be6596e548d0f1bc1ec968ee4bb97ab135a2c039de6e9f44834e17",
     ],
     data = ["@httpbin_basic_auth//file"],
 )

--- a/examples/customized/MODULE.bazel
+++ b/examples/customized/MODULE.bazel
@@ -40,6 +40,6 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 
 http_file(
     name = "httpbin_basic_auth",
-    integrity = "sha256-hi30bEnTmTImYUomWswEYBaeudFpUdWB6fE5FTrZUTg=",
-    urls = ["https://httpbin.org/basic-auth/password/swordfish"],
+    integrity = "sha256-bhFaR0m+ZZblSNDxvB7JaO5LuXqxNaLAOd5un0SDThc=",
+    urls = ["http://127.0.0.1:9494/basic-auth/password/swordfish"],
 )

--- a/testdata/basic_auth.json
+++ b/testdata/basic_auth.json
@@ -1,3 +1,3 @@
 {
-    "uri": "https://httpbin.org/basic-auth/password/swordfish"
+    "uri": "http://172.0.0.1:9494/basic-auth/password/swordfish"
 }


### PR DESCRIPTION
This will remove the flakiness from the integration tests that relied on the httpbin.org service being available.