### PR TITLE
remoteapis: detect hosted BuildBuddy with subdomain

### DIFF
--- a/authenticate/remoteapis/remoteapis.go
+++ b/authenticate/remoteapis/remoteapis.go
@@ -170,6 +170,9 @@ func configFromContext(ctx context.Context, uri *url.URL) (configFragment, error
 	if cfg, ok := wellKnownServices[uri.Host]; ok {
 		return helperconfig.FromContext(ctx, cfg)
 	}
+	if strings.HasSuffix(uri.Host, ".buildbuddy.io") {
+		return helperconfig.FromContext(ctx, wellKnownServices["remote.buildbuddy.io"])
+	}
 
 	return helperconfig.FromContext(ctx, configFragment{
 		AuthMethod: "header",

--- a/helperfactory/fallback/fallback_factory.go
+++ b/helperfactory/fallback/fallback_factory.go
@@ -33,7 +33,7 @@ func FallbackHelperFactory(rawURL string) (api.Helper, error) {
 		return &authenticateGitHub.GitHub{}, nil
 	case strings.HasSuffix(strings.ToLower(u.Hostname()), ".r2.cloudflarestorage.com") && !u.Query().Has("X-Amz-Expires"):
 		return &authenticateS3.S3{}, nil
-	case strings.EqualFold(u.Hostname(), "remote.buildbuddy.io"):
+	case strings.HasSuffix(u.Hostname(), ".buildbuddy.io"):
 		return &authenticateRemoteAPIs.RemoteAPIs{}, nil
 	case strings.HasSuffix(u.Hostname(), "pkg.dev"):
 		return &authenticateGAR.GAR{}, nil


### PR DESCRIPTION
The default "remote.buildbuddy.io" always works for hosted BuildBuddy but has some downsides (it allows unauthenticated connections, leading to hard-to-understand issues). This allows for `<orgname>.buildbuddy.io` to work out of the box.