### PR TITLE
github: fix auth header schema for raw.githubusercontent.com urls

### DIFF
--- a/authenticate/github/github.go
+++ b/authenticate/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -116,10 +117,18 @@ func (g *GitHubResolver) Get(ctx context.Context, req api.GetCredentialsRequest)
 	if !token.Expiry.IsZero() {
 		expires = token.Expiry.UTC().Format(time.RFC3339)
 	}
+	var authString string
+
+	switch {
+		case strings.EqualFold(parsedURL.Host, "raw.githubusercontent.com"):
+			authString = "Basic " + base64.StdEncoding.EncodeToString([]byte(token.AccessToken + ":"))
+		default:
+			authString = "Bearer " + token.AccessToken
+	}
 	return api.GetCredentialsResponse{
 		Expires: expires,
 		Headers: map[string][]string{
-			"Authorization": {"Bearer " + token.AccessToken},
+			"Authorization": {authString},
 		},
 	}, nil
 }


### PR DESCRIPTION
The scheme for accessing single artifacts in a repository tree via `raw.githubusercontent.com` is slightly different than the method for github.com itself. Github being Github, I can't find this written down in any official documentation, but you can see [questions][1], [discussions][2], and [gists][3] all over the place explaining it. There are two ways of doing it, apparently, but the one I discovered as working first is to use your Github token as the user component of the Basic auth scheme. 

Looks like you may also be able to use the bare token by specifying the nonstandard Token scheme in the auth header, but the choice seems fairly arbitrary.

This addresses issue #79.

[1]: https://github.com/orgs/community/discussions/160828
[2]: https://github.com/orgs/community/discussions/22537
[3]: https://gist.github.com/jcefoli/4f24620acc0521f895649c933ee6685b