### PR TITLE
add a flag to set a release version suffix

### DIFF
--- a/bzl/config/BUILD.bazel
+++ b/bzl/config/BUILD.bazel
@@ -33,6 +33,14 @@ string_flag(
     build_setting_default = "%workspace%\\tools\\credential-helper.exe",
 )
 
+string_flag(
+    name = "version_suffix",
+    # This allows a consumer of this repository to append a string to the binary's
+    # version string, e.g. ".name.1", to allow tracking local modifications.
+    build_setting_default = "",
+    make_variable = "VERSION_SUFFIX",
+)
+
 config_setting(
     name = "helper_build_mode_prebuilt",
     flag_values = {

--- a/cmd/root/BUILD.bazel
+++ b/cmd/root/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["root.go"],
     importpath = "github.com/tweag/credential-helper/cmd/root",
     visibility = ["//visibility:public"],
-    x_defs = {"version": module_version()},
+    x_defs = {"version": module_version() + "$(VERSION_SUFFIX)"},
     deps = [
         "//agent",
         "//agent/locate",
@@ -16,6 +16,9 @@ go_library(
         "//cmd/setup",
         "//config",
         "//logging",
+    ],
+    toolchains = [
+        "//bzl/config:version_suffix",
     ],
 )
 


### PR DESCRIPTION
this allows consumers to track any local modifications that may have
been made to the helper. it also requires a patch to rules_go, however
