### PR TITLE
github: check config file after any lookup failure

### DIFF
--- a/authenticate/github/github.go
+++ b/authenticate/github/github.go
@@ -159,7 +159,7 @@ type GitHubTokenSource struct {
 func (g *GitHubTokenSource) Token() (*oauth2.Token, error) {
 	chain := lookupchain.New(g.config.LookupChain)
 	token, err := chain.Lookup("default")
-	if lookupchain.IsNotFoundErr(err) && g.config.ReadConfigFile {
+	if err != nil && g.config.ReadConfigFile {
 		logging.Debugf("no token found in lookup chain - falling back to GitHub config file: %v", err)
 		const host = "github.com"
 		cfg, err := hostsFromFile(filepath.Join(configDir(), "hosts.yml"))


### PR DESCRIPTION
currently, if the default keyring lookup fails for any reason other
than not found (like the keyring couldn't be reached), the github
provider won't check the config file. i don't see why it shouldn't- the
current behavior means that the config file doesn't get checked at all
on linux machines that aren't running a desktop environment or don't
have dbus-launch in the path. we'd like that to happen, while also
checking the keyring on mac.
