### PR TITLE
script: use realpath to canonicalize workspace path

### DIFF
--- a/tools/credential-helper
+++ b/tools/credential-helper
@@ -5,7 +5,7 @@ set -o errtrace
 # This is a shell stub that wraps the real credential helper binary.
 # It can be used on Unix platforms (Linux, macOS).
 # Place this script in your Bazel workspace and make it executable.
-# On Windows, the installer places a full copy of the real credential-helper.exe 
+# On Windows, the installer places a full copy of the real credential-helper.exe
 # in the workspace, so no wrapper is needed.
 
 # You can add hardcoded configuration here or use environment variables when running Bazel
@@ -40,7 +40,7 @@ set -o errtrace
 
 credential_helper_install_command="bazel run @tweag-credential-helper//installer"
 
-export CREDENTIAL_HELPER_WORKSPACE_DIRECTORY="${CREDENTIAL_HELPER_WORKSPACE_DIRECTORY:-$(pwd)}"
+export CREDENTIAL_HELPER_WORKSPACE_DIRECTORY="${CREDENTIAL_HELPER_WORKSPACE_DIRECTORY:-$(realpath "$(pwd)")}"
 
 # Bazel spawns the credential helper process using the workspace root as working directory.
 # We abuse this fact to obtain a stable, workspace specific install dir (just like Bazel's output base).


### PR DESCRIPTION
after setting this up in our repo, i found out that some coworkers use a
pretty wild set of symlinks in their home directories that led to this
script being unable to find the credential-helper binary cache location.
using realpath to canonicalize out the symlinks (as bazel appears to do)
restored functionality for them.
