### PR TITLE
feat(remoteapis): add header_prefix config option

### DIFF
--- a/authenticate/remoteapis/remoteapis.go
+++ b/authenticate/remoteapis/remoteapis.go
@@ -120,7 +120,7 @@ func (g *RemoteAPIs) Get(ctx context.Context, req api.GetCredentialsRequest) (ap
 	headerName := cfg.HeaderName
 	secretEncoding := func(secret string) string {
 		// by default, the secret is directly used as a header value
-		return secret
+		return cfg.HeaderPrefix + secret
 	}
 	switch cfg.AuthMethod {
 	case "header":
@@ -160,6 +160,11 @@ type configFragment struct {
 	AuthMethod string `json:"auth_method"`
 	// HeaderName is the name of the header to set the secret in.
 	HeaderName string `json:"header_name"`
+	// HeaderPrefix is prepended to the secret in the header value when
+	// auth_method is "header". It is ignored for other auth methods. The
+	// empty default preserves the historical behavior of sending the secret
+	// verbatim. Common values include "Bearer " and "Token ".
+	HeaderPrefix string `json:"header_prefix"`
 	// LookupChain defines the order in which secrets are looked up from sources.
 	// Each element is a string that identifies a secret source.
 	// It defaults to the sources "env", "keyring".


### PR DESCRIPTION
## Summary

Adds a `header_prefix` string to the `remoteapis` `configFragment`. When `auth_method` is `"header"`, the prefix is prepended to the secret in the header value. The empty default preserves the historical behavior of sending the secret verbatim, so existing configs are unaffected.

## Why

The `header` auth method currently emits the secret verbatim, which works for header-based APIs that expect a raw token (e.g. `x-buildbuddy-api-key`). It does not directly cover the more common HTTP convention of `Authorization: Bearer <token>` or `Authorization: Token <token>` without the user pre-baking the prefix into their stored secret, which is awkward for keyring-backed flows and breaks if the same secret is reused with another tool.

A small generalization on the existing helper covers these cases without a new provider:

```json
{
  "auth_method": "header",
  "header_name": "Authorization",
  "header_prefix": "Bearer "
}
```

## Compatibility

- `header_prefix` defaults to `""`, so all existing configurations behave exactly as before.
- Only applies when `auth_method` is `"header"`. The `basic_auth` branch is unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Existing integration test (`integration/oci_test.go`) unaffected
- [ ] No new tests added: the `remoteapis` package has no existing unit tests, so adding one for a single config field would be inconsistent with the package's current convention. Happy to add a focused test if reviewers prefer.